### PR TITLE
prevent adding new methods to functions `>`, `>=`, `isgreater`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -208,7 +208,7 @@ Base.keys(q::UnionAbstractQuantity) = keys(ustrip(q))
 end
 
 # Numeric checks
-for op in (:(<=), :(<), :(>=), :(>), :isless), (type, true_base_type, _) in ABSTRACT_QUANTITY_TYPES
+for op in (:(<=), :(<), :isless), (type, true_base_type, _) in ABSTRACT_QUANTITY_TYPES
     # Avoid creating overly generic operations on these:
     base_type = true_base_type <: Number ? true_base_type : Number
     @eval begin
@@ -243,7 +243,7 @@ for op in (:isequal, :(==)), (type, true_base_type, _) in ABSTRACT_QUANTITY_TYPE
         end
     end
 end
-for op in (:(<=), :(<), :(>=), :(>), :isless, :isgreater, :isequal, :(==)),
+for op in (:(<=), :(<), :isless, :isequal, :(==)),
     (t1, _, _) in ABSTRACT_QUANTITY_TYPES,
     (t2, _, _) in ABSTRACT_QUANTITY_TYPES
 


### PR DESCRIPTION
As documented in the doc string of each of these three functions, these functions are not intended to get any new methods from packages.

Preventing the definition of these unnecessary methods also prevents most of the sysimage invalidation that happens when loading this package. On nightly Julia, commit JuliaLang/julia@3681bb37ec7, the unique invalidation count upon `using DynamicQuantities` goes from $1381$ to $261$.