### PR TITLE
Create alias `FRInt32` for `FixedRational{Int32, 25200}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,9 +457,13 @@ the type you wish to use as the second argument to `Quantity`:
 ```julia
 julia> using DynamicQuantities
 
-julia> q8 = [Quantity{Float64,FRInt8}(randn(), length=rand(-2:2)) for i in 1:1000];
+julia> R8 = Dimensions{FRInt8};
 
-julia> q32 = [Quantity{Float64,FRInt32}(randn(), length=rand(-2:2)) for i in 1:1000];
+julia> R32 = Dimensions{FRInt32};
+
+julia> q8 = [Quantity{Float64,R8}(randn(), length=rand(-2:2)) for i in 1:1000];
+
+julia> q32 = [Quantity{Float64,R32}(randn(), length=rand(-2:2)) for i in 1:1000];
 
 julia> f(x) = @. x ^ 2 * 0.5;
 

--- a/README.md
+++ b/README.md
@@ -423,13 +423,13 @@ julia> total_cookies = cookie_rate * total_milk
 92.7 cookies
 ```
 
-Exponents are tracked by default with the type `R = FixedRational{Int32,C}`,
-which represents rational numbers with a fixed denominator `C`.
+Exponents are tracked by default with the type `FRInt32` (alias for `FixedRational{Int32, 25200}`),
+which represents rational numbers with an integer numerator and fixed denominator.
 This is much faster than `Rational`.
 
 ```julia
 julia> typeof(0.5u"kg")
-Quantity{Float64, Dimensions{FixedRational{Int32, 25200}}}
+Quantity{Float64, Dimensions{FRInt32}}
 ```
 
 You can change the type of the value field by initializing with a value
@@ -437,17 +437,18 @@ explicitly of the desired type.
 
 ```julia
 julia> typeof(Quantity(Float16(0.5), mass=1, length=1))
-Quantity{Float16, Dimensions{FixedRational{Int32, 25200}}}
+Quantity{Float16, Dimensions{FRInt32}}
 ```
 
 or by conversion:
 
 ```julia
 julia> typeof(convert(Quantity{Float16}, 0.5u"m/s"))
-Quantity{Float16, Dimensions{FixedRational{Int32, 25200}}}
+Quantity{Float16, Dimensions{FRInt32}}
 ```
 
-For many applications, `FixedRational{Int8,6}` will suffice,
+For many applications, using `FRInt8` (alias for `FixedRational{Int8,12}`)
+will suffice as the base dimensions type,
 and can be faster as it means the entire `Dimensions`
 struct will fit into 64 bits.
 You can change the type of the dimensions field by passing
@@ -456,13 +457,9 @@ the type you wish to use as the second argument to `Quantity`:
 ```julia
 julia> using DynamicQuantities
 
-julia> R8 = Dimensions{FixedRational{Int8,6}};
+julia> q8 = [Quantity{Float64,FRInt8}(randn(), length=rand(-2:2)) for i in 1:1000];
 
-julia> R32 = Dimensions{FixedRational{Int32,2^4 * 3^2 * 5^2 * 7}};  # Default
-
-julia> q8 = [Quantity{Float64,R8}(randn(), length=rand(-2:2)) for i in 1:1000];
-
-julia> q32 = [Quantity{Float64,R32}(randn(), length=rand(-2:2)) for i in 1:1000];
+julia> q32 = [Quantity{Float64,FRInt32}(randn(), length=rand(-2:2)) for i in 1:1000];
 
 julia> f(x) = @. x ^ 2 * 0.5;
 

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ you can use a `QuantityArray`:
 
 ```julia-repl
 julia> ar = rand(3)u"m/s"
-3-element QuantityArray(::Vector{Float64}, ::Quantity{Float64, Dimensions{FixedRational{Int32, 25200}}}):
+3-element QuantityArray(::Vector{Float64}, ::Quantity{Float64, Dimensions{FRInt32}}):
  0.2729202669351497 m s⁻¹
  0.992546340360901 m s⁻¹
  0.16863543422972482 m s⁻¹

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -34,5 +34,7 @@ Filter  = t -> !(t in [ustrip, dimension, ulength, umass, utime, ucurrent, utemp
 
 ```@docs
 FixedRational
+FRInt32
+FRInt8
 DynamicQuantities.denom
 ```

--- a/src/DynamicQuantities.jl
+++ b/src/DynamicQuantities.jl
@@ -3,7 +3,7 @@ module DynamicQuantities
 export Units, Constants, SymbolicUnits, SymbolicConstants
 export AbstractQuantity, AbstractGenericQuantity, AbstractRealQuantity, UnionAbstractQuantity
 export Quantity, GenericQuantity, RealQuantity
-export FixedRational
+export FixedRational, FRInt32, FRInt8
 export AbstractDimensions, Dimensions, NoDims
 export AbstractSymbolicDimensions, SymbolicDimensions, SymbolicDimensionsSingleton
 export QuantityArray

--- a/src/types.jl
+++ b/src/types.jl
@@ -4,7 +4,21 @@ else
     @eval const static_fieldnames = fieldnames
 end
 
-const DEFAULT_DIM_BASE_TYPE = FixedRational{DEFAULT_NUMERATOR_TYPE,DEFAULT_DENOM}
+"""
+    FRInt32
+
+FixedRational with Int32 numerator and denominator 25200.
+"""
+const FRInt32 = FixedRational{DEFAULT_NUMERATOR_TYPE,DEFAULT_DENOM}
+
+"""
+    FRInt8
+
+FixedRational with Int8 numerator and denominator 12.
+"""
+const FRInt8 = FixedRational{Int8, 12}
+
+const DEFAULT_DIM_BASE_TYPE = FRInt32
 const DEFAULT_VALUE_TYPE = Float64
 
 """

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -743,8 +743,8 @@ end
         @test FRInt8 === FixedRational{Int8, 12}
         @test DEFAULT_DIM_BASE_TYPE === FRInt32
 
-        @test string(FRInt32) == "FRInt32"
-        @test string(FRInt8) == "FRInt8"
+        @test occursin("FRInt32", string(FRInt32))
+        @test occursin("FRInt8", string(FRInt8))
     end
 end
 

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -737,6 +737,15 @@ end
     x = 10u"m"
     user_quantity = Quantity(10.0, Dimensions{FixedRational{Int32,25200}}(1, 0, 0, 0, 0, 0, 0))
     @test x == user_quantity
+
+    @testset "FRInt32 and FRInt8 type aliases" begin
+        @test FRInt32 === FixedRational{Int32, 25200}
+        @test FRInt8 === FixedRational{Int8, 12}
+        @test DEFAULT_DIM_BASE_TYPE === FRInt32
+
+        @test string(FRInt32) == "FRInt32"
+        @test string(FRInt8) == "FRInt8"
+    end
 end
 
 @testset "Quantity promotion" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1691,7 +1691,7 @@ end
             io = IOBuffer()
             Base.showarg(io, z, true)
             msg = String(take!(io))
-            Q == Quantity && @test occursin(r"QuantityArray\(::Vector{Float64}, ::(DynamicQuantities\.)?Quantity{Float64, (DynamicQuantities\.)?SymbolicDimensions{(DynamicQuantities\.)?FixedRational{Int32, 25200}}}\)", msg)
+            Q == Quantity && @test occursin(r"QuantityArray\(::Vector{Float64}, ::(DynamicQuantities\.)?Quantity{Float64, (DynamicQuantities\.)?SymbolicDimensions{(DynamicQuantities\.)?FRInt32}}\)", msg)
 
             io = IOBuffer()
             Base.show(io, MIME"text/plain"(), typeof(z))


### PR DESCRIPTION
Makes the printouts easier to read. Also this creates `FRInt8=FixedRational{Int8,12}` which makes it less challenging to swap the dimensions type.

@icweaver would you be up for a review?